### PR TITLE
build: only specify least specific directory to dtbtool

### DIFF
--- a/core/tasks/dt_image.mk
+++ b/core/tasks/dt_image.mk
@@ -18,7 +18,8 @@ DTBTOOL := $(HOST_OUT_EXECUTABLES)/$(DTBTOOL_NAME)$(HOST_EXECUTABLE_SUFFIX)
 
 INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
 
-possible_dtb_dirs = $(KERNEL_OUT)/arch/$(TARGET_KERNEL_ARCH)/boot/dts/ $(KERNEL_OUT)/arch/arm/boot/
+# Most specific paths must come first in possible_dtb_dirs
+possible_dtb_dirs = $(KERNEL_OUT)/arch/$(TARGET_KERNEL_ARCH)/boot/
 dtb_dir = $(firstword $(wildcard $(possible_dtb_dirs)))
 
 define build-dtimage-target


### PR DESCRIPTION
New kernels (3.18) place dtb files into the qcom subdirectory,
but older kernels simply create a qcom subdirectory and place
the dtb files at the same level in the heirarchy.  Rather than
looking for the first directory that exists, dtbtool has been
modified to search all subdirectories for dtb files, and
therefore we have to remove the specific subdirectories.

Change-Id: I82e948c0a20605f051a60fdfaae9679e1fa6555e
