### PR TITLE
Set mcpu targets based on cpu variant.

### DIFF
--- a/core/combo/arch/arm/armv7-a-neon.mk
+++ b/core/combo/arch/arm/armv7-a-neon.mk
@@ -27,7 +27,7 @@ ifneq (,$(filter cortex-a8 scorpion,$(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT
 	arch_variant_ldflags := \
 		-Wl,--fix-cortex-a8
 else
-ifeq ($(strip $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)),cortex-a7)
+ifneq (,$(filter cortex-a7 cortex-a53 cortex-a53.a57,$(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)))
 	arch_variant_cflags := -mcpu=cortex-a7 -mfpu=neon-vfpv4
 	arch_variant_ldflags := \
 		-Wl,--no-fix-cortex-a8


### PR DESCRIPTION
Make cortex-a53 and cortex-a53.a57 use cortex-a7.

Change-Id: I89d5b3f044c867ec99aae319eafc33f2edf1f9f2
