### PR TITLE
envsetup: fix mm under zsh

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -865,7 +865,6 @@ function mm()
         local M=$(findmakefile)
         local MODULES=
         local GET_INSTALL_PATH=
-        local ARGS=
         # Remove the path to top as the makefilepath needs to be relative
         local M=`echo $M|sed 's:'$T'/::'`
         if [ ! "$T" ]; then
@@ -882,12 +881,12 @@ function mm()
             done
             if [ -n "$GET_INSTALL_PATH" ]; then
               MODULES=
-              ARGS=GET-INSTALL-PATH
+              # set all args to 'GET-INSTALL-PATH'
+              set -- GET-INSTALL-PATH
             else
               MODULES=all_modules
-              ARGS=$@
             fi
-            ONE_SHOT_MAKEFILE=$M $DRV make -C $T -f build/core/main.mk $MODULES $ARGS
+            ONE_SHOT_MAKEFILE=$M $DRV make -C $T -f build/core/main.mk $MODULES "$@"
         fi
     fi
 }


### PR DESCRIPTION
Fix a word splitting issue in zsh. Instead of building a duplicate
ARGS array for the !GET-INSTALL-PATH case, leave it untouched. For the
GET-INSTALL-PATH case, modify the argument list as needed.

Change-Id: I902ff1bc7a53e7afa8c4737d4208592ac18f95d7
